### PR TITLE
Fixed typo in 2023-10-01-rustc_codegen_gcc-progress-report-26.adoc

### DIFF
--- a/_posts/2023-10-01-rustc_codegen_gcc-progress-report-26.adoc
+++ b/_posts/2023-10-01-rustc_codegen_gcc-progress-report-26.adoc
@@ -259,7 +259,7 @@ Here are the results of running the UI tests in the CI:
 | Category | Last Month | This Month | Delta
 
 | Passed | 5445 | 5446 | +1
-| Failed | 69 | 68 | -7
+| Failed | 69 | 68 | -1
 |===
 
 // TODO: remove the (15) LTO tests from the table.


### PR DESCRIPTION
This PR fixes a typo in the latest post, making the delta in the "UI tests progress" section correct.